### PR TITLE
The :class_name attribute in has_many and belongs_to should be a string

### DIFF
--- a/lib/acts_as_rated.rb
+++ b/lib/acts_as_rated.rb
@@ -99,7 +99,7 @@ module ActiveRecord #:nodoc:
             Object.class_eval <<-EOV
               class #{rating_class} < ActiveRecord::Base
                 belongs_to :rated, :polymorphic => true
-                #{options[:no_rater] ? '' : "belongs_to :rater, :class_name => #{rater_class}, :foreign_key => :rater_id"}
+                #{options[:no_rater] ? '' : "belongs_to :rater, :class_name => '#{rater_class}', :foreign_key => :rater_id"}
               end
             EOV
           end
@@ -133,7 +133,7 @@ module ActiveRecord #:nodoc:
           rater_as_class = rater_class.constantize
           return if rater_as_class.instance_methods.include?('find_in_ratings')
           rater_as_class.class_eval <<-EOS
-            has_many :ratings, :foreign_key => :rater_id, :class_name => #{rating_class.to_s}
+            has_many :ratings, :foreign_key => :rater_id, :class_name => '#{rating_class.to_s}'
           EOS
         end
       end


### PR DESCRIPTION
The :class_name attribute in has_many and belongs_to should be a string with the name of a class, not the class itself.

The text inside "class_eval" which define these associations lacked the appropriate quotes.

This was causing an obscure error when upgrading my app to Rails 2.3.11 and the latest version of active_scaffold plugin
